### PR TITLE
Update BNU WebVPN Host

### DIFF
--- a/data/webvpn.json
+++ b/data/webvpn.json
@@ -56,7 +56,7 @@
       "host": "webvpn.bipt.edu.cn"
     },
     "北京师范大学": {
-      "host": "webvpn.bnu.edu.cn",
+      "host": "onevpn.bnu.edu.cn",
       "crypto_key": "wrdvpnisthebest!",
       "crypto_iv": "wrdvpnisthebest!"
     },


### PR DESCRIPTION
北师大的 WebVPN 地址实际已更改为 https://onevpn.bnu.edu.cn/ ，原来的地址只是登录跳转入口。